### PR TITLE
✨ Standard header names are tagged for fast lookup

### DIFF
--- a/src/connection.zig
+++ b/src/connection.zig
@@ -70,7 +70,7 @@ pub const Client = struct {
 
 const expect = std.testing.expect;
 const expectError = std.testing.expectError;
-const HeaderMap = @import("http").HeaderMap;
+const Headers = @import("http").Headers;
 const Request = @import("events.zig").Request;
 
 test "Send - Client can send an event" {
@@ -86,9 +86,9 @@ test "Send - Remember the request method when sending a request event" {
     var client = Client.init(std.testing.allocator);
     defer client.deinit();
 
-    var headers = HeaderMap.init(std.testing.allocator);
+    var headers = Headers.init(std.testing.allocator);
     defer headers.deinit();
-    _ = try headers.put("Host", "www.ziglang.org");
+    _ = try headers.append("Host", "www.ziglang.org");
 
     var request = try Request.init(.Get, "/", .Http11, headers);
     var bytes = try client.send(Event {.Request = request });
@@ -132,7 +132,7 @@ test "NextEvent - A Response event with no content length must be followed by an
     client.sentRequestMethod = .Get;
 
     try client.receive("HTTP/1.1 200 OK\r\n\r\n");
-    var event = try client.nextEvent();
+    var event = try client.nextEvent(); //TODO: CA PETE ICI
     event.deinit();
 
    event = try client.nextEvent();

--- a/src/events/response.zig
+++ b/src/events/response.zig
@@ -1,13 +1,13 @@
-const HeaderMap = @import("http").HeaderMap;
+const Headers = @import("http").Headers;
 const StatusCode = @import("http").StatusCode;
 const Version = @import("http").Version;
 
 pub const Response = struct {
-    headers: HeaderMap,
+    headers: Headers,
     statusCode: StatusCode,
     version: Version,
 
-    pub fn init(headers: HeaderMap, statusCode: StatusCode, version: Version) Response {
+    pub fn init(headers: Headers, statusCode: StatusCode, version: Version) Response {
         return Response {
             .headers = headers,
             .statusCode = statusCode,
@@ -16,6 +16,7 @@ pub const Response = struct {
     }
 
     pub fn deinit(self: Response) void {
-        self.headers.deinit();
+        var headers = self.headers;
+        headers.deinit();
     }
 };

--- a/src/parsers/errors.zig
+++ b/src/parsers/errors.zig
@@ -1,5 +1,6 @@
 pub const ParsingError = error {
     Incomplete,
     Invalid,
+    OutOfMemory,
     TooManyHeaders,
 };

--- a/src/parsers/headers.zig
+++ b/src/parsers/headers.zig
@@ -1,156 +1,79 @@
+const Allocator = std.mem.Allocator;
+const Headers = @import("http").Headers;
 const ParsingError = @import("errors.zig").ParsingError;
 const readLine = @import("utils.zig").readLine;
 const std = @import("std");
 
-pub const Header = struct {
-    name: []const u8,
-    value: []const u8,
 
-    pub fn parse(buffer: []const u8, headers: []?Header) ParsingError![]?Header {
-        var cursor: usize = 0;
-        var header_cursor: usize = 0;
+pub fn parse(allocator: *Allocator, buffer: []const u8, max_headers: usize) ParsingError!Headers {
+    var cursor: usize = 0;
+    var headers = Headers.init(allocator);
+    errdefer headers.deinit();
 
-        while (true) {
-            var remaining_bytes = buffer[cursor..];
-            if (remaining_bytes.len < 2) {
-                return error.Incomplete;
-            }
-            if (remaining_bytes[0] == '\r' and remaining_bytes[1] == '\n') {
-                return headers[0..header_cursor];
-            }
+    while (true) {
+        var remaining_bytes = buffer[cursor..];
+        if (remaining_bytes.len < 2) {
+            return error.Incomplete;
+        }
 
-            if (header_cursor >= headers.len) {
-                return error.TooManyHeaders;
-            }
+        if (remaining_bytes[0] == '\r' and remaining_bytes[1] == '\n') {
+            break;
+        }
 
-            const header_name = for (remaining_bytes) |char, i| {
-                if (char == ':') {
-                    const name = remaining_bytes[0..i];
-                    cursor += i + 1;
-                    break name;
-                } else if (!is_header_name_token(char)) {
-                    return error.Invalid;
-                }
-            } else {
-                return error.Incomplete;
-            };
+        if (headers.len() >= max_headers) {
+            return error.TooManyHeaders;
+        }
 
-            // Consume the optional whitespace between the semicolon and the header value
-            // Cf: https://tools.ietf.org/html/rfc7230#section-3.2
-            remaining_bytes = buffer[cursor..];
-            for (remaining_bytes) |char, i| {
-                if (is_linear_whitespace(char)) {
-                    cursor += 1;
-                    break;
-                } else if (is_header_value_token(char)) {
-                    break;
-                }
-                else {
-                    return error.Invalid;
-                }
-            } else {
-                return error.Incomplete;
+        const header_name = for (remaining_bytes) |char, i| {
+            if (char == ':') {
+                const name = remaining_bytes[0..i];
+                cursor += i + 1;
+                break name;
             }
+        } else {
+            return error.Incomplete;
+        };
 
-            remaining_bytes = buffer[cursor..];
-            const header_value = for (remaining_bytes) |char, i| {
-                if (!is_header_value_token(char)) {
-                    const value = remaining_bytes[0..i];
-                    cursor += i;
-                    break value;
-                }
-            } else {
-                return error.Incomplete;
-            };
+        // Consume the optional whitespace between the semicolon and the header value
+        // Cf: https://tools.ietf.org/html/rfc7230#section-3.2
+        remaining_bytes = buffer[cursor..];
+        for (remaining_bytes) |char, i| {
+            if (is_linear_whitespace(char)) {
+                cursor += 1;
+            }
+            break;
+        } else {
+            return error.Incomplete;
+        }
 
-            remaining_bytes = buffer[cursor..]; 
-            if (remaining_bytes.len < 2) {
-                return error.Incomplete;
+        remaining_bytes = buffer[cursor..];
+        const header_value = for (remaining_bytes) |char, i| {
+            if (char == '\r') {
+                cursor += i;
+                break remaining_bytes[0..i];
             }
-            if (remaining_bytes[0] == '\r' and remaining_bytes[1] == '\n') {
-                headers[header_cursor] = Header {.name = header_name, .value = header_value};
-                header_cursor += 1;
-                cursor += 2;
-                continue;
-            }
-            else {
-                return error.Invalid;
-            }
+        } else {
+            return error.Incomplete;
+        };
+
+        remaining_bytes = buffer[cursor..];
+        if (remaining_bytes.len < 2) {
+            return error.Incomplete;
+        }
+        if (remaining_bytes[0] == '\r' and remaining_bytes[1] == '\n') {
+            try headers.append(header_name, header_value);
+            cursor += 2;
+        }
+        else {
+            return error.Invalid;
         }
     }
-};
 
-// ASCII codes accepted for an header's name
-// Cf: Borrowed from Seamonstar's httparse library
-// https://github.com/seanmonstar/httparse/blob/01e68542605d8a24a707536561c27a336d4090dc/src/lib.rs#L96
-const HEADER_NAME_MAP = [_]bool {
-    false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false,
-//   \0                                                             \t     \n                   \r
-    false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false,
-//   commands
-    false, true, false, true, true, true, true, true, false, false, true, true, false, true, true, false,
-//   \s     !     "      #     $     %     &     '     (      )      *     +     ,      -     .     /
-    true, true, true, true, true, true, true, true, true, true, false, false, false, false, false, false,
-//   0     1     2     3     4     5     6     7     8     9     :      ;      <      =      >      ?
-    false, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true,
-//   @      A     B     C     D     E     F     G     H     I     J     K     L     M     N     O
-    true, true, true, true, true, true, true, true, true, true, true, false, false, false, true, true,
-//   P     Q     R     S     T     U     V     W     X     Y     Z     [      \      ]      ^     _
-    true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true,
-//   `     a     b     c     d     e     f     g     h     i     j     k     l     m     n     o
-    true, true, true, true, true, true, true, true, true, true, true, false, true, false, true, false,
-//   p     q     r     s     t     u     v     w     x     y     z     {      |     }      ~     del
-//   ====== Extended ASCII (aka. obs-text) ======
-    false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false,
-    false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false,
-    false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false,
-    false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false,
-    false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false,
-    false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false,
-    false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false,
-    false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false,
-};
-
-// ASCII codes accepted for an header's value
-// Cf: Borrowed from Seamonstar's httparse library
-// https://github.com/seanmonstar/httparse/blob/01e68542605d8a24a707536561c27a336d4090dc/src/lib.rs#L120
-const HEADER_VALUE_MAP = [_]bool {
-    false, false, false, false, false, false, false, false, false, true, false, false, false, false, false, false,
-//   \0                                                             \t    \n                   \r
-    false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false,
-//   commands
-    true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true,
-//   \s    !     "     #     $     %     &     '     (     )     *     +     ,     -     .     /
-    true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true,
-//   0     1     2     3     4     5     6     7     8     9     :     ;     <     =     >     ?
-    true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true,
-//   @     A     B     C     D     E     F     G     H     I     J     K     L     M     N     O
-    true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true,
-//   P     Q     R     S     T     U     V     W     X     Y     Z     [     \     ]     ^     _
-    true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true,
-//   `     a     b     c     d     e     f     g     h     i     j     k     l     m     n     o
-    true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, false,
-//   p     q     r     s     t     u     v     w     x     y     z     {     |     }     ~     del
-//   ====== Extended ASCII (aka. obs-text) ======
-    true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true,
-    true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true,
-    true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true,
-    true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true,
-    true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true,
-    true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true,
-    true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true,
-    true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true,
-};
-
-fn is_header_name_token(char: u8) bool {
-    return HEADER_NAME_MAP[char];
+    return headers;
 }
 
-fn is_header_value_token(char: u8) bool {
-    return HEADER_VALUE_MAP[char];
-}
 
-fn is_linear_whitespace(char: u8) bool {
+inline fn is_linear_whitespace(char: u8) bool {
     return char == ' ' or char == '\t';
 }
 
@@ -160,118 +83,101 @@ const expectError = std.testing.expectError;
 
 test "Parse - Single header - Success" {
     const content = "Content-Length: 10\r\n\r\n";
-    var headers: [1]?Header = undefined;
 
-    var result = try Header.parse(content, &headers);
+    var headers = try parse(std.testing.allocator, content, 1);
+    defer headers.deinit();
 
-    expect(std.mem.eql(u8, result[0].?.name, "Content-Length"));
-    expect(std.mem.eql(u8, result[0].?.value, "10"));
+    const header = headers.items()[0];
+    expect(std.mem.eql(u8, header.name.raw(), "Content-Length"));
+    expect(std.mem.eql(u8, header.value, "10"));
 }
 
 test "Parse - Multiple headers - Success" {
     const content = "Content-Length: 10\r\nServer: Apache\r\n\r\n";
-    var headers: [2]?Header = undefined;
 
-    const result = try Header.parse(content, &headers);
+    var headers = try parse(std.testing.allocator, content, 2);
+    defer headers.deinit();
 
-    expect(std.mem.eql(u8, result[0].?.name, "Content-Length"));
-    expect(std.mem.eql(u8, result[0].?.value, "10"));
+    const content_length = headers.items()[0];
+    expect(std.mem.eql(u8, content_length.name.raw(), "Content-Length"));
+    expect(std.mem.eql(u8, content_length.value, "10"));
 
-    expect(std.mem.eql(u8, result[1].?.name, "Server"));
-    expect(std.mem.eql(u8, result[1].?.value, "Apache"));
-}
-
-test "Parse - Resize header slice - Success" {
-    const content = "Content-Length: 10\r\n\r\n";
-    var headers: [2]?Header = undefined;
-
-    const result = try Header.parse(content, &headers);
-
-    expect(result.len == 1);
+    const server = headers.items()[1];
+    expect(std.mem.eql(u8, server.name.raw(), "Server"));
+    expect(std.mem.eql(u8, server.value, "Apache"));
 }
 
 test "Parse - Ignore a missing whitespace between the semicolon and the header value - Success" {
     const content = "Content-Length:10\r\n\r\n";
-    var headers: [1]?Header = undefined;
 
-    const result = try Header.parse(content, &headers);
+    var headers = try parse(std.testing.allocator, content, 1);
+    defer headers.deinit();
 
-    expect(std.mem.eql(u8, result[0].?.name, "Content-Length"));
-    expect(std.mem.eql(u8, result[0].?.value, "10"));
+    const header = headers.items()[0];
+    expect(std.mem.eql(u8, header.name.raw(), "Content-Length"));
+    expect(std.mem.eql(u8, header.value, "10"));
 }
 
 test "Parse - When the last CRLF after the headers is missing - Returns Incomplete" {
     const content = "Content-Length: 10\r\n";
-    var headers: [1]?Header = undefined;
 
-    const fail = Header.parse(content, &headers);
+    const fail = parse(std.testing.allocator, content, 1);
+
     expectError(error.Incomplete, fail);
 }
 
 test "Parse - When a header's name does not end with a semicolon - Returns Incomplete" {
-    const content = "Content-Length: 10\r\nSe";
-    var headers: [2]?Header = undefined;
+    const content = "Content-Length";
 
-    const fail = Header.parse(content, &headers);
+    const fail = parse(std.testing.allocator, content, 1);
+
     expectError(error.Incomplete, fail);
 }
 
 test "Parse - When a header's value does not exist - Returns Incomplete" {
     const content = "Content-Length:";
-    var headers: [2]?Header = undefined;
 
-    const fail = Header.parse(content, &headers);
+    const fail = parse(std.testing.allocator, content, 1);
+
     expectError(error.Incomplete, fail);
 }
 
 test "Parse - When a header's value does not exist (but the whitespace after the semicolon is here) - Returns Incomplete" {
     const content = "Content-Length: ";
-    var headers: [2]?Header = undefined;
 
-    const fail = Header.parse(content, &headers);
+    const fail = parse(std.testing.allocator, content, 1);
+
     expectError(error.Incomplete, fail);
 }
 
 test "Parse - When LF is mising after a header's value - Returns Incomplete" {
     const content = "Content-Length: 10\r";
-    var headers: [1]?Header = undefined;
 
-    const fail = Header.parse(content, &headers);
+    const fail = parse(std.testing.allocator, content, 1);
 
     expectError(error.Incomplete, fail);
 }
 
 test "Parse - When parsing more headers than expected - Returns TooManyHeaders" {
     const content = "Content-Length: 10\r\nServer: Apache\r\n\r\n";
-    var headers: [1]?Header = undefined;
 
-    const fail = Header.parse(content, &headers);
+    const fail = parse(std.testing.allocator, content, 1);
+
     expectError(error.TooManyHeaders, fail);
 }
 
 test "Parse - Invalid character in the header's name - Returns Invalid" {
     const content = "Cont(ent-Length: 10\r\n\r\n";
-    var headers: [1]?Header = undefined;
 
-    const fail = Header.parse(content, &headers);
-
-    expectError(error.Invalid, fail);
-}
-
-test "Parse - Invalid character in the header's value after the semicolon - Returns Invalid" {
-    const content = "Content-Length:\r\n";
-    var headers: [1]?Header = undefined;
-
-    const fail = Header.parse(content, &headers);
+    const fail = parse(std.testing.allocator, content, 1);
 
     expectError(error.Invalid, fail);
 }
 
 test "Parse - Invalid character in the header's value - Returns Invalid" {
     const content = "Content-Length: 1\r0\r\n";
-    var headers: [1]?Header = undefined;
 
-    const fail = Header.parse(content, &headers);
+    const fail = parse(std.testing.allocator, content, 1);
 
     expectError(error.Invalid, fail);
 }

--- a/src/parsers/main.zig
+++ b/src/parsers/main.zig
@@ -1,4 +1,3 @@
-pub const Header = @import("headers.zig").Header;
 pub const Request = @import("request.zig").Request;
 pub const Response = @import("response.zig").Response;
 pub const Error = @import("errors.zig").ParsingError;

--- a/src/readers.zig
+++ b/src/readers.zig
@@ -90,24 +90,27 @@ pub const BodyReader = union(BodyReaderType) {
             return .NoContent;
         }
 
+
         var contentLength: usize = 0;
-        var rawContentLength = response.headers.getValue("Content-Length");
-        if (rawContentLength != null) {
-            contentLength = fmt.parseInt(usize, rawContentLength.?, 10) catch return Error.RemoteProtocolError;
+        var contentLengthHeader = response.headers.get("Content-Length");
+
+        if (contentLengthHeader != null) {
+            contentLength = fmt.parseInt(usize, contentLengthHeader.?.value, 10) catch return Error.RemoteProtocolError;
         }
+
         return BodyReader { .ContentLength = ContentLengthReader.init(contentLength) };
     }
 };
 
 
 const expect = std.testing.expect;
-const HeaderMap = @import("http").HeaderMap;
+const Headers = @import("http").Headers;
 const std = @import("std");
 const StatusCode = @import("http").StatusCode;
 
 
 test "Frame Body - A HEAD request has no content" {
-    var headers = HeaderMap.init(std.testing.allocator);
+    var headers = Headers.init(std.testing.allocator);
     var response = Response.init(headers, .Ok, .Http11);
 
     var reader = try BodyReader.frame(.Head, response);
@@ -116,7 +119,7 @@ test "Frame Body - A HEAD request has no content" {
 }
 
 test "Frame Body - Informational responses (1XX status code) have no content" {
-    var headers = HeaderMap.init(std.testing.allocator);
+    var headers = Headers.init(std.testing.allocator);
     var response = Response.init(headers, .Continue, .Http11);
 
     var reader = try BodyReader.frame(.Get, response);
@@ -125,7 +128,7 @@ test "Frame Body - Informational responses (1XX status code) have no content" {
 }
 
 test "Frame Body - Response with a 204 No Content status code has no content" {
-    var headers = HeaderMap.init(std.testing.allocator);
+    var headers = Headers.init(std.testing.allocator);
     var response = Response.init(headers, .NoContent, .Http11);
 
     var reader = try BodyReader.frame(.Get, response);
@@ -134,7 +137,7 @@ test "Frame Body - Response with a 204 No Content status code has no content" {
 }
 
 test "Frame Body - Response with 304 Not Modified status code has no content" {
-    var headers = HeaderMap.init(std.testing.allocator);
+    var headers = Headers.init(std.testing.allocator);
     var response = Response.init(headers, .NotModified, .Http11);
 
     var reader = try BodyReader.frame(.Get, response);
@@ -143,7 +146,7 @@ test "Frame Body - Response with 304 Not Modified status code has no content" {
 }
 
 test "Frame Body - A successful response (2XX) to a CONNECT request has no content" {
-    var headers = HeaderMap.init(std.testing.allocator);
+    var headers = Headers.init(std.testing.allocator);
     var response = Response.init(headers, .Ok, .Http11);
 
     var reader = try BodyReader.frame(.Connect, response);

--- a/src/state_machines/client.zig
+++ b/src/state_machines/client.zig
@@ -1,7 +1,7 @@
 const Allocator = std.mem.Allocator;
 const Data = @import("../events.zig").Data;
 const Event = @import("../events.zig").Event;
-const HeaderMap = @import("http").HeaderMap;
+const Headers = @import("http").Headers;
 const Method = @import("http").Method;
 const Request = @import("../events.zig").Request;
 const State = @import("states.zig").State;
@@ -71,9 +71,9 @@ const expectError = std.testing.expectError;
 test "Send - Can send a Request event when state is Idle" {
     var client = ClientSM.init(std.testing.allocator);
 
-    var headers = HeaderMap.init(std.testing.allocator);
-    _ = try headers.put("Host", "www.ziglang.org");
-    _ = try headers.put("GOTTA-GO", "FAST!");
+    var headers = Headers.init(std.testing.allocator);
+    _ = try headers.append("Host", "www.ziglang.org");
+    _ = try headers.append("GOTTA-GO", "FAST!");
     defer headers.deinit();
 
     var requestEvent = try Request.init(Method.Get, "/", Version.Http11, headers);


### PR DESCRIPTION
- Allow fast lookup for standard headers within *h11* by tagging them during the parsing
- Standard header name can be retrieved *raw* (case insensitive) or *clean* (lower-cased)
- Header name tagging should be case insensitive

*Inspiration*:
Rust [http](https://github.com/hyperium/http/blob/master/src/header/name.rs) crate.